### PR TITLE
Updated remote_setup_pc to connect to the Internet then Movo.

### DIFF
--- a/movo_remote_pc_setup/setup_remote_pc
+++ b/movo_remote_pc_setup/setup_remote_pc
@@ -110,6 +110,17 @@ if [ ! -f ~/.ssh/id_rsa.pub ]; then
     fi
 fi
 
+echo "\nWould you like to initialize and build the local workspace?"
+read -r -p "Build local workspace? [y/N] " response
+if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]
+then
+    echo "\n Building local workspace. \n\n"
+    cd ~/movo_ws/src
+    catkin_init_workspace
+    cd ~/movo_ws  
+    catkin_make
+fi
+
 echo -e "\nScript has finished configuring the remote PC.\n\nWould you like to connect to the physical Movo robot now?"
 
 read -r -p "Connect to the Movo [y/N] " response

--- a/movo_remote_pc_setup/setup_remote_pc
+++ b/movo_remote_pc_setup/setup_remote_pc
@@ -16,42 +16,26 @@ export MOVO_SETUP_DIR=$PWD
 echo -e "\nNeed sudo persmission to do the configuration and setup\nPlease enter your password if prompted....\n"
 echo "$USER ALL=(ALL) NOPASSWD:ALL" | (sudo su -c 'EDITOR="tee -a" visudo') >> /dev/null
 
-temp=1
-temp1=1
+temp2=1
 cnts=0
 while [ $cnts -lt 10 ]; do
-    echo -e "\nPlease connect to the robot via ethernet cable\nand to the internet another interface\n\nPress any key to continue....\n"
+    echo -e "\nPlease connect to the internet via Ethernet or WiFi.\n\nPress any key to continue....\n"
     read -n 1 -s
-    ping -q -c 1 -W 1 10.66.171.1 >/dev/null
-    temp=$?
-    ping -q -c 1 -W 1 10.66.171.2 >/dev/null
-    temp1=$?
     ping -q -c 1 -W 1 8.8.8.8 >/dev/null
     temp2=$?
     cnts=$[$cnts+1]
-    echo "$temp $temp1 $temp2"
-    if [ $temp -eq 0 ] && [ $temp1 -eq 0 ] && [ $temp2 -eq 0 ]; then
+    echo "$temp2"
+    if [ $temp2 -eq 0 ]; then
       cnts=10
       echo "Success"
       break
     fi
 
-    if [ $temp -ne 0 ]; then
-      echo "Unable to ping movo2, no robot connection....trying again."
-    fi
-    if [ $temp1 -ne 0 ]; then
-      echo "Unable to ping movo1, no robot connection....trying again."
-    fi    
     if [ $temp2 -ne 0 ]; then
       echo "Unable to ping Google DNS, no internet connection....trying again."
     fi
 done 
 
-if [ $temp -ne 0 ] || [ $temp1 -ne 0 ]; then
-  echo "Robot Connection timed out, try again....exiting"
-  sleep 2
-  exit 1
-fi
 if [ $temp2 -ne 0 ]; then
   echo "Internet Connection timed out, try again....exiting"
   sleep 2
@@ -126,6 +110,52 @@ if [ ! -f ~/.ssh/id_rsa.pub ]; then
     fi
 fi
 
+echo -e "\nScript has finished configuring the remote PC.\n\nWould you like to connect to the physical Movo robot now?"
+
+read -r -p "Connect to the Movo [y/N] " response
+if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]
+then
+    echo "Connecting to Movo......"
+    sleep 1
+else
+    source ~/.bashrc
+    echo -e "\nNot connecting to Movo robot.\n\nPress any key to exit....\n"
+    read -n 1 -s
+    exit 1
+fi
+
+temp=1
+temp1=1
+cnts=0
+while [ $cnts -lt 10 ]; do
+    echo -e "\nPlease connect to the robot over Ethernet or WiFi \n\nPress any key to continue....\n"
+    read -n 1 -s
+    ping -q -c 1 -W 1 10.66.171.1 >/dev/null
+    temp=$?
+    ping -q -c 1 -W 1 10.66.171.2 >/dev/null
+    temp1=$?
+    cnts=$[$cnts+1]
+    echo "$temp $temp1"
+    if [ $temp -eq 0 ] && [ $temp1 -eq 0 ]; then
+      cnts=10
+      echo "Success"
+      break
+    fi
+
+    if [ $temp -ne 0 ]; then
+      echo "Unable to ping movo2, no robot connection....trying again."
+    fi
+    if [ $temp1 -ne 0 ]; then
+      echo "Unable to ping movo1, no robot connection....trying again."
+    fi
+done 
+
+if [ $temp -ne 0 ] || [ $temp1 -ne 0 ]; then
+  echo "Robot Connection timed out, try again....exiting"
+  sleep 2
+  exit 1
+fi
+
 echo 'Connecting to movo1 (password is Welcome00)......Press any key to continue'
 read -n 1 -s
 ssh -oHostKeyAlgorithms='ssh-rsa' movo@movo1 "sleep 1; exit"
@@ -185,8 +215,7 @@ else
     
 fi
 source ~/.bashrc
-echo -e "\nScript has finished configuring the remote PC\n\nPress any key to continue....\n"
+echo -e "\nScript has finished updating the robot.\n\nPress any key to exit....\n"
 read -n 1 -s
 exit 1
-
 


### PR DESCRIPTION
This change enables the use case of a researcher wanting to set up a computer for simulation and future connection to the Movo without physical access to the robot during setup. The existing structure of the script requires the computer to be connected to both the Movo and the Internet from the start, even though the contents of the script do one then the other. Builds on an initial version sent via email by @martine1406.